### PR TITLE
Fixed ZeroDivisionError for perf_complete value

### DIFF
--- a/repeatProgressChecks.py
+++ b/repeatProgressChecks.py
@@ -35,7 +35,8 @@ def checkProgress(nProcess, tag, percentages):
                     nentriesPerProc=end
                     perc_complete = int(100.0*current/end)
                 else:
-                    perc_complete = int(100.0*(current-(end-nentriesPerProc))/nentriesPerProc)
+                    eps = 1e-9
+                    perc_complete = int(100.0*(current-(end-nentriesPerProc)+eps)/(nentriesPerProc+eps))
                 current_percentages[iproc]=perc_complete
 
                 #######################


### PR DESCRIPTION
By adding epsilon, this ensures that perc_complete never divides by zero as seen in some instances but keeps the correct percentage complete.